### PR TITLE
Fix the unpack command not being able to run via the /execute command

### DIFF
--- a/src/main/java/net/doubledoordev/itemblacklist/util/CommandUnpack.java
+++ b/src/main/java/net/doubledoordev/itemblacklist/util/CommandUnpack.java
@@ -4,7 +4,9 @@ import net.doubledoordev.itemblacklist.data.GlobalBanList;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.command.PlayerNotFoundException;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentString;
 
@@ -32,7 +34,7 @@ public class CommandUnpack extends CommandBase
     @Override
     public boolean checkPermission(MinecraftServer server, ICommandSender sender)
     {
-        return sender instanceof EntityPlayer;
+        return sender.getCommandSenderEntity() instanceof EntityPlayer;
     }
 
     @Override
@@ -44,8 +46,20 @@ public class CommandUnpack extends CommandBase
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
     {
-        EntityPlayer player = getCommandSenderAsPlayer(sender);
+        EntityPlayer player = getCommandSenderEntityAsPlayer(sender);
         int count = GlobalBanList.process(player.dimension, player.inventory, true);
         sender.sendMessage(new TextComponentString("Unlocked " + count + " items."));
+    }
+
+    private static EntityPlayerMP getCommandSenderEntityAsPlayer(ICommandSender sender) throws PlayerNotFoundException
+    {
+        if (sender.getCommandSenderEntity() instanceof EntityPlayerMP)
+        {
+            return (EntityPlayerMP) sender.getCommandSenderEntity();
+        }
+        else
+        {
+            throw new PlayerNotFoundException("commands.generic.player.unspecified");
+        }
     }
 }


### PR DESCRIPTION
This issue came up via a user being unable to use the `/unpack` command via World Primer.
Because the unpack command was checking the `ICommandSender` itself for being a player entity (instead of the entity gotten from the `getCommandSenderEntity()` method), running the `/unpack` command via the vanilla `/execute` command was impossible, since that command wraps the target entity (in this case the player)  inside a `CommandSenderWrapper`.